### PR TITLE
Behavioural change for stale/expired data in Gcache and AsynCache

### DIFF
--- a/async_cache.go
+++ b/async_cache.go
@@ -150,8 +150,8 @@ func (ks *keyStatus) purge() {
 
 func (ac *AsyncCache) AsyncGet(key string) (interface{}, Status) {
 	//Fetching from cache
-	data, ok := ac.Get(key)
-	if ok {
+	data, found := ac.Get(key)
+	if found {
 		return data, STATUS_DONE
 	}
 	ac.keystatus.lock()
@@ -167,7 +167,12 @@ func (ac *AsyncCache) AsyncGet(key string) (interface{}, Status) {
 	ac.keystatus.unlock()
 	//asyncCall to DB/dataSource
 	go ac.asyncUpdate(key)
-	//returning data and cache/keystatus
+
+	//returning stale data instead of empty with STATUS-DONE
+	if data != nil {
+		return data, STATUS_DONE
+	}
+	// return empty data and in-process for ideal first call
 	return data, STATUS_INPROCESS
 }
 

--- a/async_cache_test.go
+++ b/async_cache_test.go
@@ -284,6 +284,28 @@ func TestAsyncCache_AsyncGet(t *testing.T) {
 				return *ac
 			}(),
 		},
+		{name: "Returning Expired Stale data instead of Empty",
+			args: args{
+				key: "PROF_5890",
+			},
+			want:       "Expired-Stale-Data",
+			wantStatus: STATUS_DONE,
+			as: func() AsyncCache {
+				f := NewFetcher(4)
+				f.Register("PROF", getProf)
+				f.Register("CONF", getConf)
+				config := Config{
+					Fetcher:             f,
+					PurgeTime:           10 * time.Millisecond,
+					ExpiryTime:          1 * time.Microsecond,
+					ErrorFuncDefination: ErrorHandler,
+				}
+				ac := NewAsyncCache(&config)
+				ac.keystatus.Set("PROF_5890", STATUS_DONE)
+				ac.Set("PROF_5890", "Expired-Stale-Data", ac.defaultExpiration)
+				return *ac
+			}(),
+		},
 	}
 	for _, tt := range tests {
 

--- a/cache.go
+++ b/cache.go
@@ -128,7 +128,7 @@ func (c *cache) Get(k string) (interface{}, bool) {
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
-			return nil, false
+			return item.Object, false
 		}
 	}
 	c.mu.RUnlock()

--- a/cache_test.go
+++ b/cache_test.go
@@ -1769,3 +1769,18 @@ func TestGetWithExpiration(t *testing.T) {
 		t.Error("expiration for e is in the past")
 	}
 }
+
+func TestGet(t *testing.T) {
+	//behavioural change , returns still data if data is expired
+	tc := New(1*time.Microsecond, 0)
+	tc.Set("key", "Expired-Stale-Data", tc.defaultExpiration)
+	//expiring data expilictly
+	time.Sleep(1 * time.Microsecond)
+	data, found := tc.Get("key")
+	if !found && data == nil {
+		t.Error("Cache not returning staled data ")
+	} else if found {
+		t.Errorf("Cache should Return false for staled data")
+	}
+
+}


### PR DESCRIPTION
Go-cache Behavioural Change: 

1. Will return stale/expired  data with present flag as `false`

AsyncCache Behavioural Change: 

1. Will return stale data with STATUS_DONE ( keeping behavior aligned to data present)
2. Will call `asyncUpdate` routine to again refresh data
   